### PR TITLE
Remove pytest-lazy-fixture

### DIFF
--- a/tests/unit/campaign/test_config.py
+++ b/tests/unit/campaign/test_config.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pandas as pd
 import pytest
 from numpy.testing import assert_array_equal
-from pytest_lazyfixture import lazy_fixture
 
 from blueetl.campaign import config as test_module
 from blueetl.utils import dump_yaml, load_yaml
@@ -15,24 +14,26 @@ from tests.unit.utils import TEST_DATA_PATH, assert_frame_equal
     "input_dict, expected_obj",
     [
         (
-            lazy_fixture("xarray_config_dict_simple"),
-            lazy_fixture("blueetl_config_obj_simple"),
+            "xarray_config_dict_simple",
+            "blueetl_config_obj_simple",
         ),
         (
-            lazy_fixture("xarray_config_dict_coupled"),
-            lazy_fixture("blueetl_config_obj_coupled"),
+            "xarray_config_dict_coupled",
+            "blueetl_config_obj_coupled",
         ),
         (
-            lazy_fixture("blueetl_config_dict_simple"),
-            lazy_fixture("blueetl_config_obj_simple"),
+            "blueetl_config_dict_simple",
+            "blueetl_config_obj_simple",
         ),
         (
-            lazy_fixture("blueetl_config_dict_coupled"),
-            lazy_fixture("blueetl_config_obj_coupled"),
+            "blueetl_config_dict_coupled",
+            "blueetl_config_obj_coupled",
         ),
     ],
 )
-def test_simulations_config_load(tmp_path, input_dict, expected_obj):
+def test_simulations_config_load(tmp_path, input_dict, expected_obj, lazy_fixture):
+    input_dict = lazy_fixture(input_dict)
+    expected_obj = lazy_fixture(expected_obj)
     config_path = tmp_path / "config.yaml"
     dump_yaml(config_path, input_dict)
 
@@ -49,16 +50,18 @@ def test_simulations_config_load(tmp_path, input_dict, expected_obj):
     "input_obj, expected_dict",
     [
         (
-            lazy_fixture("blueetl_config_obj_simple"),
-            lazy_fixture("blueetl_config_dict_simple"),
+            "blueetl_config_obj_simple",
+            "blueetl_config_dict_simple",
         ),
         (
-            lazy_fixture("blueetl_config_obj_coupled"),
-            lazy_fixture("blueetl_config_dict_coupled"),
+            "blueetl_config_obj_coupled",
+            "blueetl_config_dict_coupled",
         ),
     ],
 )
-def test_simulations_config_dump(tmp_path, input_obj, expected_dict):
+def test_simulations_config_dump(tmp_path, input_obj, expected_dict, lazy_fixture):
+    input_obj = lazy_fixture(input_obj)
+    expected_dict = lazy_fixture(expected_dict)
     config_path = tmp_path / "config.yaml"
 
     input_obj.dump(config_path)
@@ -70,11 +73,12 @@ def test_simulations_config_dump(tmp_path, input_obj, expected_dict):
 @pytest.mark.parametrize(
     "input_dict",
     [
-        lazy_fixture("blueetl_config_dict_simple"),
-        lazy_fixture("blueetl_config_dict_coupled"),
+        "blueetl_config_dict_simple",
+        "blueetl_config_dict_coupled",
     ],
 )
-def test_simulations_config_load_dump_roundtrip(tmp_path, input_dict):
+def test_simulations_config_load_dump_roundtrip(tmp_path, input_dict, lazy_fixture):
+    input_dict = lazy_fixture(input_dict)
     config_path_1 = tmp_path / "config_1.yaml"
     config_path_2 = tmp_path / "config_2.yaml"
     dump_yaml(config_path_1, input_dict)
@@ -92,16 +96,18 @@ def test_simulations_config_load_dump_roundtrip(tmp_path, input_dict):
     "input_dict, expected_obj",
     [
         (
-            lazy_fixture("blueetl_config_dict_simple"),
-            lazy_fixture("blueetl_config_obj_simple"),
+            "blueetl_config_dict_simple",
+            "blueetl_config_obj_simple",
         ),
         (
-            lazy_fixture("blueetl_config_dict_coupled"),
-            lazy_fixture("blueetl_config_obj_coupled"),
+            "blueetl_config_dict_coupled",
+            "blueetl_config_obj_coupled",
         ),
     ],
 )
-def test_simulations_config_from_dict(input_dict, expected_obj):
+def test_simulations_config_from_dict(input_dict, expected_obj, lazy_fixture):
+    input_dict = lazy_fixture(input_dict)
+    expected_obj = lazy_fixture(expected_obj)
     result = test_module.SimulationCampaign.from_dict(input_dict)
 
     assert isinstance(result, test_module.SimulationCampaign)
@@ -112,16 +118,18 @@ def test_simulations_config_from_dict(input_dict, expected_obj):
     "input_dict, expected_obj",
     [
         (
-            lazy_fixture("xarray_config_dict_simple"),
-            lazy_fixture("blueetl_config_obj_simple"),
+            "xarray_config_dict_simple",
+            "blueetl_config_obj_simple",
         ),
         (
-            lazy_fixture("xarray_config_dict_coupled"),
-            lazy_fixture("blueetl_config_obj_coupled"),
+            "xarray_config_dict_coupled",
+            "blueetl_config_obj_coupled",
         ),
     ],
 )
-def test_simulations_config_from_xarray_dict(input_dict, expected_obj):
+def test_simulations_config_from_xarray_dict(input_dict, expected_obj, lazy_fixture):
+    input_dict = lazy_fixture(input_dict)
+    expected_obj = lazy_fixture(expected_obj)
     result = test_module.SimulationCampaign.from_xarray_dict(input_dict)
 
     assert isinstance(result, test_module.SimulationCampaign)
@@ -132,16 +140,19 @@ def test_simulations_config_from_xarray_dict(input_dict, expected_obj):
     "input_obj, expected_dict",
     [
         (
-            lazy_fixture("blueetl_config_obj_simple"),
-            lazy_fixture("blueetl_config_dict_simple"),
+            "blueetl_config_obj_simple",
+            "blueetl_config_dict_simple",
         ),
         (
-            lazy_fixture("blueetl_config_obj_coupled"),
-            lazy_fixture("blueetl_config_dict_coupled"),
+            "blueetl_config_obj_coupled",
+            "blueetl_config_dict_coupled",
         ),
     ],
 )
-def test_simulations_config_to_dict(input_obj, expected_dict):
+def test_simulations_config_to_dict(input_obj, expected_dict, lazy_fixture):
+    input_obj = lazy_fixture(input_obj)
+    expected_dict = lazy_fixture(expected_dict)
+
     result = input_obj.to_dict()
 
     assert isinstance(result, dict)
@@ -152,16 +163,19 @@ def test_simulations_config_to_dict(input_obj, expected_dict):
     "input_obj, expected_dict",
     [
         (
-            lazy_fixture("blueetl_config_obj_simple"),
-            lazy_fixture("xarray_config_dict_simple"),
+            "blueetl_config_obj_simple",
+            "xarray_config_dict_simple",
         ),
         (
-            lazy_fixture("blueetl_config_obj_coupled"),
-            lazy_fixture("xarray_config_dict_coupled"),
+            "blueetl_config_obj_coupled",
+            "xarray_config_dict_coupled",
         ),
     ],
 )
-def test_simulations_config_to_xarray_dict(input_obj, expected_dict):
+def test_simulations_config_to_xarray_dict(input_obj, expected_dict, lazy_fixture):
+    input_obj = lazy_fixture(input_obj)
+    expected_dict = lazy_fixture(expected_dict)
+
     result = input_obj.to_xarray_dict()
 
     assert isinstance(result, dict)
@@ -173,16 +187,19 @@ def test_simulations_config_to_xarray_dict(input_obj, expected_dict):
     "input_obj, expected_df",
     [
         (
-            lazy_fixture("blueetl_config_obj_simple"),
-            lazy_fixture("blueetl_config_dataframe_simple"),
+            "blueetl_config_obj_simple",
+            "blueetl_config_dataframe_simple",
         ),
         (
-            lazy_fixture("blueetl_config_obj_coupled"),
-            lazy_fixture("blueetl_config_dataframe_coupled"),
+            "blueetl_config_obj_coupled",
+            "blueetl_config_dataframe_coupled",
         ),
     ],
 )
-def test_simulations_config_get_all(input_obj, expected_df):
+def test_simulations_config_get_all(input_obj, expected_df, lazy_fixture):
+    input_obj = lazy_fixture(input_obj)
+    expected_df = lazy_fixture(expected_df)
+
     result = input_obj.get()
 
     assert isinstance(result, pd.DataFrame)
@@ -193,8 +210,8 @@ def test_simulations_config_get_all(input_obj, expected_df):
 @pytest.mark.parametrize(
     "input_obj",
     [
-        lazy_fixture("blueetl_config_obj_simple"),
-        lazy_fixture("blueetl_config_obj_coupled"),
+        "blueetl_config_obj_simple",
+        "blueetl_config_obj_coupled",
     ],
 )
 @pytest.mark.parametrize(
@@ -204,7 +221,8 @@ def test_simulations_config_get_all(input_obj, expected_df):
         ("CircuitConfig", False),
     ],
 )
-def test_simulations_config_is_sonata(input_obj, filename, expected):
+def test_simulations_config_is_sonata(input_obj, filename, expected, lazy_fixture):
+    input_obj = lazy_fixture(input_obj)
     input_obj.attrs["circuit_config"] = f"/path/to/{filename}"
     result = input_obj.is_sonata()
     assert result == expected
@@ -213,11 +231,12 @@ def test_simulations_config_is_sonata(input_obj, filename, expected):
 @pytest.mark.parametrize(
     "input_obj",
     [
-        lazy_fixture("blueetl_config_obj_simple"),
-        lazy_fixture("blueetl_config_obj_coupled"),
+        "blueetl_config_obj_simple",
+        "blueetl_config_obj_coupled",
     ],
 )
-def test_simulations_config_is_sonata_raises(input_obj):
+def test_simulations_config_is_sonata_raises(input_obj, lazy_fixture):
+    input_obj = lazy_fixture(input_obj)
     del input_obj.attrs["circuit_config"]
     with pytest.raises(RuntimeError, match="circuit_config is missing in the simulation campaign"):
         input_obj.is_sonata()
@@ -226,11 +245,12 @@ def test_simulations_config_is_sonata_raises(input_obj):
 @pytest.mark.parametrize(
     "input_obj, expected_len",
     [
-        (lazy_fixture("blueetl_config_obj_simple"), 4),
-        (lazy_fixture("blueetl_config_obj_coupled"), 2),
+        ("blueetl_config_obj_simple", 4),
+        ("blueetl_config_obj_coupled", 2),
     ],
 )
-def test_simulations_config_len(input_obj, expected_len):
+def test_simulations_config_len(input_obj, expected_len, lazy_fixture):
+    input_obj = lazy_fixture(input_obj)
     result = len(input_obj)
     assert result == expected_len
 
@@ -238,11 +258,12 @@ def test_simulations_config_len(input_obj, expected_len):
 @pytest.mark.parametrize(
     "input_obj, expected_len",
     [
-        (lazy_fixture("blueetl_config_obj_simple"), 4),
-        (lazy_fixture("blueetl_config_obj_coupled"), 2),
+        ("blueetl_config_obj_simple", 4),
+        ("blueetl_config_obj_coupled", 2),
     ],
 )
-def test_simulations_config_iter(input_obj, expected_len):
+def test_simulations_config_iter(input_obj, expected_len, lazy_fixture):
+    input_obj = lazy_fixture(input_obj)
     count = 0
     for sim in input_obj:
         assert isinstance(sim, test_module.SimulationRow)
@@ -253,11 +274,12 @@ def test_simulations_config_iter(input_obj, expected_len):
 @pytest.mark.parametrize(
     "input_obj, expected_len",
     [
-        (lazy_fixture("blueetl_config_obj_simple"), 4),
-        (lazy_fixture("blueetl_config_obj_coupled"), 2),
+        ("blueetl_config_obj_simple", 4),
+        ("blueetl_config_obj_coupled", 2),
     ],
 )
-def test_simulations_config_getitem(input_obj, expected_len):
+def test_simulations_config_getitem(input_obj, expected_len, lazy_fixture):
+    input_obj = lazy_fixture(input_obj)
     for i in range(expected_len):
         sim = input_obj[i]
         assert isinstance(sim, test_module.SimulationRow)
@@ -266,11 +288,13 @@ def test_simulations_config_getitem(input_obj, expected_len):
 @pytest.mark.parametrize(
     "input_obj, expected_data, expected_index",
     [
-        (lazy_fixture("blueetl_config_obj_simple"), [[2.0, 4.0]], [3]),
-        (lazy_fixture("blueetl_config_obj_coupled"), [[2.0, 4.0]], [1]),
+        ("blueetl_config_obj_simple", [[2.0, 4.0]], [3]),
+        ("blueetl_config_obj_coupled", [[2.0, 4.0]], [1]),
     ],
 )
-def test_simulations_config_get(input_obj, expected_data, expected_index):
+def test_simulations_config_get(input_obj, expected_data, expected_index, lazy_fixture):
+    input_obj = lazy_fixture(input_obj)
+
     result = input_obj.get(ca=2.0, depolarization=4.0)
 
     columns = ["ca", "depolarization"]
@@ -281,11 +305,13 @@ def test_simulations_config_get(input_obj, expected_data, expected_index):
 @pytest.mark.parametrize(
     "input_obj, expected_ids",
     [
-        (lazy_fixture("blueetl_config_obj_simple"), [3]),
-        (lazy_fixture("blueetl_config_obj_coupled"), [1]),
+        ("blueetl_config_obj_simple", [3]),
+        ("blueetl_config_obj_coupled", [1]),
     ],
 )
-def test_simulations_config_ids(input_obj, expected_ids):
+def test_simulations_config_ids(input_obj, expected_ids, lazy_fixture):
+    input_obj = lazy_fixture(input_obj)
+
     result = input_obj.ids(ca=2.0, depolarization=4.0)
 
     assert_array_equal(result, expected_ids)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.fixture
+def lazy_fixture(request):
+    """Return a function that returns the actual fixture from its name."""
+    return lambda name: request.getfixturevalue(name)

--- a/tests/unit/store/test_feather.py
+++ b/tests/unit/store/test_feather.py
@@ -1,6 +1,5 @@
 import pytest
 from pandas.testing import assert_frame_equal
-from pytest_lazyfixture import lazy_fixture
 
 from blueetl.store import feather as test_module
 
@@ -8,13 +7,14 @@ from blueetl.store import feather as test_module
 @pytest.mark.parametrize(
     "df",
     [
-        lazy_fixture("storable_df_with_unnamed_index"),
-        lazy_fixture("storable_df_with_named_index"),
-        lazy_fixture("storable_df_with_unnamed_multiindex"),
-        lazy_fixture("storable_df_with_named_multiindex"),
+        "storable_df_with_unnamed_index",
+        "storable_df_with_named_index",
+        "storable_df_with_unnamed_multiindex",
+        "storable_df_with_named_multiindex",
     ],
 )
-def test_dump_load_roundtrip(tmp_path, df):
+def test_dump_load_roundtrip(tmp_path, df, lazy_fixture):
+    df = lazy_fixture(df)
     name = "myname"
     store = test_module.FeatherStore(tmp_path)
 

--- a/tests/unit/store/test_hdf.py
+++ b/tests/unit/store/test_hdf.py
@@ -1,6 +1,5 @@
 import pytest
 from pandas.testing import assert_frame_equal
-from pytest_lazyfixture import lazy_fixture
 
 from blueetl.store import hdf as test_module
 
@@ -8,13 +7,14 @@ from blueetl.store import hdf as test_module
 @pytest.mark.parametrize(
     "df",
     [
-        lazy_fixture("storable_df_with_unnamed_index"),
-        lazy_fixture("storable_df_with_named_index"),
-        lazy_fixture("storable_df_with_unnamed_multiindex"),
-        lazy_fixture("storable_df_with_named_multiindex"),
+        "storable_df_with_unnamed_index",
+        "storable_df_with_named_index",
+        "storable_df_with_unnamed_multiindex",
+        "storable_df_with_named_multiindex",
     ],
 )
-def test_dump_load_roundtrip(tmp_path, df):
+def test_dump_load_roundtrip(tmp_path, df, lazy_fixture):
+    df = lazy_fixture(df)
     name = "myname"
     store = test_module.HDFStore(tmp_path)
 

--- a/tests/unit/store/test_parquet.py
+++ b/tests/unit/store/test_parquet.py
@@ -1,6 +1,5 @@
 import pytest
 from pandas.testing import assert_frame_equal
-from pytest_lazyfixture import lazy_fixture
 
 from blueetl.store import parquet as test_module
 
@@ -8,13 +7,13 @@ from blueetl.store import parquet as test_module
 @pytest.mark.parametrize(
     "df",
     [
-        lazy_fixture("storable_df_with_unnamed_index"),
-        lazy_fixture("storable_df_with_named_index"),
-        lazy_fixture("storable_df_with_named_multiindex"),
+        "storable_df_with_unnamed_index",
+        "storable_df_with_named_index",
+        "storable_df_with_named_multiindex",
         # fastparquet 0.8.1 fails to write DataFrames with MultiIndexes without names,
         # but probably it's not a good idea to use them anyway. See the code at:
         # https://github.com/dask/fastparquet/blob/34069fe2a41a7491e5b7b1f1b2cae9c41176f7b8/fastparquet/util.py#L140-L144
-        # lazy_fixture("storable_df_with_unnamed_multiindex"),
+        # "storable_df_with_unnamed_multiindex",
     ],
 )
 @pytest.mark.parametrize(
@@ -51,7 +50,8 @@ from blueetl.store import parquet as test_module
         ),
     ],
 )
-def test_dump_load_roundtrip(tmp_path, df, dump_options, load_options):
+def test_dump_load_roundtrip(tmp_path, df, dump_options, load_options, lazy_fixture):
+    df = lazy_fixture(df)
     name = "myname"
     store = test_module.ParquetStore(tmp_path)
     if dump_options is not None:

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 name = blueetl
 path = src/blueetl
 testdeps =
-    pytest<8
-    pytest-lazy-fixture
+    pytest
     pytest-cov
     coverage[toml]
 


### PR DESCRIPTION
Replace `pytest-lazy-fixture` (apparently unmaintained and incompatible with pytest 8.0) with a simple fixture `lazy_fixture` that can be called to get the actual fixture.