### PR TITLE
Consider an empty node_id list as an empty selection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Version 0.8.2
+-------------
+
+Bug Fixes
+~~~~~~~~~
+
+- If ``node_id`` in the neuron_classes configuration is set to an empty list, it's now considered as an empty selection instead of selecting all the neurons.
+
 Version 0.8.1
 -------------
 

--- a/src/blueetl/extract/base.py
+++ b/src/blueetl/extract/base.py
@@ -21,7 +21,13 @@ class BaseExtractor(ABC):
     _allow_empty_data = False
 
     def __init__(self, df: pd.DataFrame, cached: bool, filtered: bool) -> None:
-        """Initialize the extractor."""
+        """Initialize the extractor.
+
+        Args:
+            df: Pandas DataFrame containing the extracted data.
+            cached: True if the data have been extracted from the cache, False otherwise.
+            filtered: True if the data have been filtered using a custom query, False otherwise.
+        """
         self._cached = cached
         self._filtered = filtered
         self._validate(df)
@@ -39,7 +45,7 @@ class BaseExtractor(ABC):
     @classmethod
     def _validate_data(cls, df: pd.DataFrame) -> None:
         """Validate the content of the dataframe."""
-        if not cls._allow_empty_data and len(df) == 0:
+        if not cls._allow_empty_data and df.empty:
             raise RuntimeError(f"No data extracted to {cls.__name__}")
 
     @classmethod
@@ -85,7 +91,8 @@ class BaseExtractor(ABC):
             if not any(df.index.names):
                 # reset the index to remove any gap
                 df = df.reset_index(drop=True)
-        return cls(df, cached=cached, filtered=len(df) != original_len)
+        filtered = len(df) != original_len
+        return cls(df, cached=cached, filtered=filtered)
 
     def to_pandas(self) -> pd.DataFrame:
         """Return a dataframe that can be serialized and stored to disk.

--- a/src/blueetl/extract/neuron_classes.py
+++ b/src/blueetl/extract/neuron_classes.py
@@ -64,7 +64,7 @@ class NeuronClasses(BaseExtractor):
                     LIMIT: config.limit,
                     POPULATION: config.population,
                     NODE_SET: config.node_set,
-                    GIDS: json.dumps(config.node_id) if config.node_id else None,
+                    GIDS: json.dumps(config.node_id) if config.node_id is not None else None,
                     QUERY: json.dumps(config.query),
                 }
             )

--- a/src/blueetl/extract/neurons.py
+++ b/src/blueetl/extract/neurons.py
@@ -75,7 +75,7 @@ def _filter_gids_by_neuron_class(
         node_sets_file=config.node_sets_file,
     )
     gids = cells.etl.q(config.query).index.to_numpy()
-    if config.node_id:
+    if config.node_id is not None:
         gids = np.intersect1d(gids, config.node_id)
     neuron_count = len(gids)
     if config.limit and neuron_count > config.limit:

--- a/src/blueetl/extract/simulations.py
+++ b/src/blueetl/extract/simulations.py
@@ -160,10 +160,7 @@ class Simulations(BaseExtractor):
     def from_config(cls, config: SimulationCampaign, query: Optional[dict] = None) -> "Simulations":
         """Extract simulations from the given simulation campaign."""
         df = config.get()
-        original_len = len(df)
-        df = cls._from_paths(df)
-        df = cls._filter_simulations_df(df, query)
-        return cls(df, cached=False, filtered=len(df) != original_len)
+        return cls.from_pandas(df=df, query=query, cached=False)
 
     @classmethod
     def from_pandas(
@@ -175,8 +172,9 @@ class Simulations(BaseExtractor):
         """Extract simulations from a dataframe containing valid simulation ids and circuit ids."""
         original_len = len(df)
         df = cls._from_paths(df)
-        df = cls._filter_simulations_df(df, query, cached=True)
-        return cls(df, cached=cached, filtered=len(df) != original_len)
+        df = cls._filter_simulations_df(df, query, cached=cached)
+        filtered = len(df) != original_len
+        return cls(df, cached=cached, filtered=filtered)
 
     def to_pandas(self) -> pd.DataFrame:
         """Dump simulations to a dataframe that can be serialized and stored."""

--- a/src/blueetl/repository.py
+++ b/src/blueetl/repository.py
@@ -75,7 +75,7 @@ class SimulationsExtractor(BaseExtractor[Simulations]):
 
     def extract_cached(self, df: pd.DataFrame) -> Simulations:
         """Instantiate an object from a cached DataFrame."""
-        return Simulations.from_pandas(df, query=self._repo.simulations_filter)
+        return Simulations.from_pandas(df, query=self._repo.simulations_filter, cached=True)
 
 
 class NeuronsExtractor(BaseExtractor[Neurons]):
@@ -94,7 +94,7 @@ class NeuronsExtractor(BaseExtractor[Neurons]):
         if self._repo.simulations_filter:
             selected_sims = self._repo.simulations.df.etl.q(simulation_id=self._repo.simulation_ids)
             query = {CIRCUIT_ID: sorted(set(selected_sims[CIRCUIT_ID]))}
-        return Neurons.from_pandas(df, query=query)
+        return Neurons.from_pandas(df, query=query, cached=True)
 
 
 class NeuronClassesExtractor(BaseExtractor[NeuronClasses]):
@@ -112,7 +112,7 @@ class NeuronClassesExtractor(BaseExtractor[NeuronClasses]):
         if self._repo.simulations_filter:
             selected_sims = self._repo.simulations.df.etl.q(simulation_id=self._repo.simulation_ids)
             query = {CIRCUIT_ID: sorted(set(selected_sims[CIRCUIT_ID]))}
-        return NeuronClasses.from_pandas(df, query=query)
+        return NeuronClasses.from_pandas(df, query=query, cached=True)
 
 
 class WindowsExtractor(BaseExtractor[Windows]):
@@ -133,7 +133,7 @@ class WindowsExtractor(BaseExtractor[Windows]):
         query = {}
         if self._repo.simulations_filter:
             query = {SIMULATION_ID: self._repo.simulation_ids}
-        return Windows.from_pandas(df, query=query)
+        return Windows.from_pandas(df, query=query, cached=True)
 
 
 class SpikesExtractor(BaseExtractor[Spikes]):
@@ -154,7 +154,7 @@ class SpikesExtractor(BaseExtractor[Spikes]):
         query = {}
         if self._repo.simulations_filter:
             query = {SIMULATION_ID: self._repo.simulation_ids}
-        return Spikes.from_pandas(df, query=query)
+        return Spikes.from_pandas(df, query=query, cached=True)
 
 
 class SomaReportExtractor(BaseExtractor[SomaReport]):
@@ -175,7 +175,7 @@ class SomaReportExtractor(BaseExtractor[SomaReport]):
         query = {}
         if self._repo.simulations_filter:
             query = {SIMULATION_ID: self._repo.simulation_ids}
-        return SomaReport.from_pandas(df, query=query)
+        return SomaReport.from_pandas(df, query=query, cached=True)
 
 
 class CompartmentReportExtractor(BaseExtractor[CompartmentReport]):
@@ -196,7 +196,7 @@ class CompartmentReportExtractor(BaseExtractor[CompartmentReport]):
         query = {}
         if self._repo.simulations_filter:
             query = {SIMULATION_ID: self._repo.simulation_ids}
-        return CompartmentReport.from_pandas(df, query=query)
+        return CompartmentReport.from_pandas(df, query=query, cached=True)
 
 
 class Repository:


### PR DESCRIPTION
If node_id in the neuron_classes configuration is set to an empty list, it's now considered as an empty selection instead of selecting all the neurons.