### PR TITLE
[NSETM-2279] Use shared memory to write partial DataFrames of features

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+Version 0.9.1
+-------------
+
+Improvements
+~~~~~~~~~~~~
+
+- Improve performance of report extraction and features calculation by writing partial DataFrames to the shared memory (or temp directory, if shared memory is not available).
+  Both the used memory and the execution time should be lower than before, when processing large DataFrames.
+- Use zstd compression instead of snappy when writing parquet files.
+- When ``repo`` is pickled, extract the DataFrames only if they aren't already stored in the cache.
+- Remove fastparquet extra dependency.
+
 Version 0.9.0
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,6 @@ dynamic = ["version"]
 [project.optional-dependencies]
 extra = [
     # extra requirements that may be dropped at some point
-    "fastparquet>=0.8.3,!=2023.1.0", # needed by pandas to read and write parquet files
-    "orjson", # faster json decoder used by fastparquet
     "tables>=3.6.1", # needed by pandas to read and write hdf files
 ]
 external = [

--- a/src/blueetl/extract/report.py
+++ b/src/blueetl/extract/report.py
@@ -1,9 +1,12 @@
 """Generic Report extractor."""
 
 import logging
+import tempfile
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
-from typing import NamedTuple, Optional, TypeVar
+from functools import partial
+from pathlib import Path
+from typing import Callable, NamedTuple, Optional, TypeVar
 
 import pandas as pd
 from blueetl_core.utils import smart_concat
@@ -16,6 +19,8 @@ from blueetl.extract.neurons import Neurons
 from blueetl.extract.simulations import Simulations
 from blueetl.extract.windows import Windows
 from blueetl.parallel import merge_filter
+from blueetl.store.parquet import ParquetStore
+from blueetl.utils import ensure_dtypes, get_shmdir, timed
 
 L = logging.getLogger(__name__)
 ReportExtractorT = TypeVar("ReportExtractorT", bound="ReportExtractor")
@@ -96,33 +101,55 @@ class ReportExtractor(BaseExtractor, metaclass=ABCMeta):
         Returns:
             New instance.
         """
-
-        def _func(key: NamedTuple, df_list: list[pd.DataFrame]) -> tuple[NamedTuple, pd.DataFrame]:
-            # executed in a subprocess
-            simulations_df, neurons_df, windows_df = df_list
-            simulation_id, simulation = simulations_df.etl.one()[[SIMULATION_ID, SIMULATION]]
-            assert simulation_id == key.simulation_id  # type: ignore[attr-defined]
-            df_list = []
-            for inner_key, df in neurons_df.etl.groupby_iter([CIRCUIT_ID, NEURON_CLASS]):
-                population = neuron_classes.df.etl.one(
-                    circuit_id=inner_key.circuit_id, neuron_class=inner_key.neuron_class
-                )[POPULATION]
-                result_df = cls._load_values(
-                    simulation=simulation,
-                    population=population,
-                    gids=df[GID],
-                    windows_df=windows_df,
+        with tempfile.TemporaryDirectory(prefix="blueetl_", dir=get_shmdir()) as _temp_folder:
+            with timed(L.info, "Executing merge_filter "):
+                func = partial(
+                    _merge_filter_func,
+                    temp_folder=Path(_temp_folder),
                     name=name,
+                    neuron_classes_df=neuron_classes.df,
+                    dataframe_builder=cls._load_values,
                 )
-                result_df[[SIMULATION_ID, *inner_key._fields]] = [simulation_id, *inner_key]
-                df_list.append(result_df)
-            return smart_concat(df_list, ignore_index=True)
+                merge_filter(
+                    df_list=[simulations.df, neurons.df, windows.df],
+                    groupby=[SIMULATION_ID, CIRCUIT_ID],
+                    func=func,
+                )
+            with timed(L.info, "Executing concatenation"):
+                df = ParquetStore(Path(_temp_folder)).load()
+                df = ensure_dtypes(df)
+            return cls(df, cached=False, filtered=False)
 
-        all_df = merge_filter(
-            df_list=[simulations.df, neurons.df, windows.df],
-            groupby=[SIMULATION_ID, CIRCUIT_ID],
-            func=_func,
-            parallel=True,
+
+def _merge_filter_func(
+    task_index: int,
+    key: NamedTuple,
+    df_list: list[pd.DataFrame],
+    temp_folder: Path,
+    name: str,
+    neuron_classes_df: pd.DataFrame,
+    dataframe_builder: Callable[..., pd.DataFrame],
+) -> None:
+    """Executed in a subprocess, write a partial DataFrame to temp_folder."""
+    # pylint: disable=too-many-locals
+    simulations_df, neurons_df, windows_df = df_list
+    simulation_id, simulation = simulations_df.etl.one()[[SIMULATION_ID, SIMULATION]]
+    assert simulation_id == key.simulation_id  # type: ignore[attr-defined]
+    df_list = []
+    for inner_key, df in neurons_df.etl.groupby_iter([CIRCUIT_ID, NEURON_CLASS]):
+        population = neuron_classes_df.etl.one(
+            circuit_id=inner_key.circuit_id, neuron_class=inner_key.neuron_class
+        )[POPULATION]
+        result_df = dataframe_builder(
+            simulation=simulation,
+            population=population,
+            gids=df[GID],
+            windows_df=windows_df,
+            name=name,
         )
-        df = smart_concat(all_df, ignore_index=True)
-        return cls(df, cached=False, filtered=False)
+        result_df[[SIMULATION_ID, *inner_key._fields]] = [simulation_id, *inner_key]
+        df_list.append(result_df)
+    result_df = smart_concat(df_list, ignore_index=True)
+    # the conversion to the desired dtype here is important to reduce memory usage and cpu time
+    result_df = ensure_dtypes(result_df)
+    ParquetStore(temp_folder).dump(result_df, name=f"{task_index:08d}")

--- a/src/blueetl/store/base.py
+++ b/src/blueetl/store/base.py
@@ -26,7 +26,7 @@ class BaseStore(ABC):
             basedir: base directory where the files should be stored.
         """
         self._basedir = resolve_path(basedir)
-        L.info("Using class %s with basedir %s", self.__class__.__name__, self.basedir)
+        L.debug("Using class %s with basedir %s", self.__class__.__name__, self.basedir)
 
     @property
     def basedir(self) -> Path:
@@ -51,12 +51,17 @@ class BaseStore(ABC):
         self.path(name).unlink(missing_ok=True)
 
     def path(self, name: str) -> Path:
-        """Return the full path of the file with the given name and the class extension."""
-        return self.basedir / f"{name}.{self.extension}"
+        """Return the full path of the file with the given name and the class extension.
+
+        If name is empty, then return the base directory.
+        This can be useful when working with partitioned DataFrames and
+        directories containing multiple files.
+        """
+        return self.basedir / f"{name}.{self.extension}" if name else self.basedir
 
     def checksum(self, name: str) -> Optional[str]:
         """Return a checksum of the file, or None if it doesn't exist."""
         path = self.path(name)
-        if path.exists():
+        if path.is_file():
             return checksum(path)
         return None

--- a/src/blueetl/store/parquet.py
+++ b/src/blueetl/store/parquet.py
@@ -1,15 +1,68 @@
 """Parquet data store."""
 
 import logging
+from pathlib import Path
 from typing import Any, Optional
 
 import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 
 from blueetl.store.base import BaseStore
 from blueetl.types import StrOrPath
 from blueetl.utils import timed
 
 L = logging.getLogger(__name__)
+
+
+def _get_unified_schema(path: StrOrPath) -> pa.Schema:
+    """Infer and return the unified schema from all the parquet files in the given directory.
+
+    Needed because pq.read_table() would infer the schema from just the first file,
+    unless a metadata file is used. See:
+    https://github.com/ueshin/apache-arrow/blob/0a2cf3ac/python/pyarrow/parquet.py#L724
+
+    This can cause problems when a column in the first file contains empty lists,
+    since they are considered as:
+
+      times: list<element: null>
+        child 0, element: null
+
+    while in other files containing lists of floats they are considered as:
+
+      times: list<element: double>
+        child 0, element: double
+
+    and with pyarrow 15.0.0 this would raise:
+
+      ArrowNotImplementedError:
+        Unsupported cast from double to null using function cast_null
+
+    Processing all the parquet files could require some time (around 4 seconds for 13824 files
+    stored in the shared memory /dev/shm), so it doesn't parse all the files if possible.
+
+    If the performance are improved, we could replace the content of the function with:
+
+        schemas = [pq.read_schema(file_path) for file_path in Path(path).iterdir()]
+        return pa.unify_schemas(schemas)
+    """
+    with timed(L.debug, f"Inferring schema for {path}") as messages:
+        schemas = []
+        null_list_type = pa.list_(pa.null())
+        valid_fields: dict[str, bool] = {}
+        for file_path in Path(path).iterdir():
+            all_valid = True
+            file_schema = pq.read_schema(file_path)
+            for field in file_schema:
+                if valid_fields.get(field.name, False) is False:
+                    valid_fields[field.name] = not field.type.equals(null_list_type)
+                    all_valid = all_valid and valid_fields[field.name]
+            schemas.append(file_schema)
+            if all_valid:
+                # break because the merged schema doesn't contain any list of nulls
+                break
+        messages.append(f"with {len(schemas)} loaded schemas")
+        return pa.unify_schemas(schemas)
 
 
 class ParquetStore(BaseStore):
@@ -20,23 +73,12 @@ class ParquetStore(BaseStore):
         super().__init__(basedir=basedir)
         self._dump_options: dict[str, Any] = {
             "engine": "pyarrow",
-            # "engine": "fastparquet",
-            # "compression": "snappy",
-            # "index": None,
-            # "partition_cols": None,
-            # "storage_options": None,
+            # zstd typically provides a higher compression ratio than snappy,
+            # and the cpu time is similar
+            "compression": "zstd",
         }
         self._load_options: dict[str, Any] = {
-            # pyarrow (8.0.0, 9.0.0) may be affected by a memory leak,
-            # and it's slower than fastparquet when reading dataframes with columns
-            # containing lists encoded using the Dremel encoding.
-            # See https://issues.apache.org/jira/browse/ARROW-17399
-            # However, using a different engine for writing and reading may be less safe.
             "engine": "pyarrow",
-            # "engine": "fastparquet",
-            # "columns": None,
-            # "storage_options": None,
-            # "use_nullable_dtypes": False,
         }
 
     @property
@@ -44,20 +86,29 @@ class ParquetStore(BaseStore):
         """Return the file extension to be used with this specific data store."""
         return "parquet"
 
-    def dump(self, df: pd.DataFrame, name: str) -> None:
+    def dump(self, df: pd.DataFrame, name: str, **kwargs) -> None:
         """Save a dataframe to file, using the given name and the class extension."""
         path = self.path(name)
         # Unless the parameter "index" is explicitly enforced, ensure that RangeIndex
         # is converted to Int64Index in MultiIndexes with Pandas >= 1.5.0.
         # See https://github.com/apache/arrow/issues/33030
         index = True if isinstance(df.index, pd.MultiIndex) else None
-        with timed(L.debug, f"Writing {name} to {path}"):
-            df.to_parquet(path=path, **{"index": index, **self._dump_options})
+        with timed(L.debug, f"Writing {name or 'files'} to {path}"):
+            df.to_parquet(path=path, **{"index": index, **self._dump_options, **kwargs})
 
-    def load(self, name: str) -> Optional[pd.DataFrame]:
-        """Load a dataframe from file, using the given name and the class extension."""
+    def load(self, name: str = "", **kwargs) -> Optional[pd.DataFrame]:
+        """Load a dataframe from file, using the given name and the class extension.
+
+        If name is empty, then consider and load all the files in the directory.
+        """
         path = self.path(name)
         if not path.exists():
             return None
-        with timed(L.debug, f"Reading {name} from {path}"):
-            return pd.read_parquet(path=path, **self._load_options)
+        if "schema" in kwargs:
+            schema = kwargs.pop("schema")
+        elif path.is_dir():
+            schema = _get_unified_schema(path)
+        else:
+            schema = None
+        with timed(L.debug, f"Reading {name or 'files'} from {path}"):
+            return pd.read_parquet(path=path, **{"schema": schema, **self._load_options, **kwargs})

--- a/tests/unit/store/test_parquet.py
+++ b/tests/unit/store/test_parquet.py
@@ -1,5 +1,7 @@
+import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
+from pyarrow import ArrowNotImplementedError
 
 from blueetl.store import parquet as test_module
 
@@ -10,56 +12,53 @@ from blueetl.store import parquet as test_module
         "storable_df_with_unnamed_index",
         "storable_df_with_named_index",
         "storable_df_with_named_multiindex",
-        # fastparquet 0.8.1 fails to write DataFrames with MultiIndexes without names,
-        # but probably it's not a good idea to use them anyway. See the code at:
-        # https://github.com/dask/fastparquet/blob/34069fe2a41a7491e5b7b1f1b2cae9c41176f7b8/fastparquet/util.py#L140-L144
-        # "storable_df_with_unnamed_multiindex",
+        "storable_df_with_unnamed_multiindex",
     ],
 )
-@pytest.mark.parametrize(
-    "dump_options, load_options",
-    [
-        # test the configuration actually used
-        (None, None),
-        # test other possible configurations not used yet
-        ({"engine": "pyarrow", "index": None}, {"engine": "pyarrow"}),
-        ({"engine": "fastparquet", "index": None}, {"engine": "fastparquet"}),
-        pytest.param(
-            {"engine": "fastparquet", "index": True},
-            {"engine": "fastparquet"},
-            marks=pytest.mark.xfail(
-                reason="Fails because index names are different ('index', None)",
-                raises=AssertionError,
-            ),
-        ),
-        pytest.param(
-            {"engine": "pyarrow"},
-            {"engine": "fastparquet"},
-            marks=pytest.mark.xfail(
-                reason="Fails because column e is loaded as float64 instead of object",
-                raises=AssertionError,
-            ),
-        ),
-        pytest.param(
-            {"engine": "fastparquet"},
-            {"engine": "pyarrow"},
-            marks=pytest.mark.xfail(
-                reason="Fails because column h is loaded as bytes instead of object",
-                raises=AssertionError,
-            ),
-        ),
-    ],
-)
-def test_dump_load_roundtrip(tmp_path, df, dump_options, load_options, lazy_fixture):
+def test_dump_load_roundtrip(tmp_path, df, lazy_fixture):
     df = lazy_fixture(df)
     name = "myname"
-    store = test_module.ParquetStore(tmp_path)
-    if dump_options is not None:
-        store._dump_options = dump_options
-    if load_options is not None:
-        store._load_options = load_options
 
+    store = test_module.ParquetStore(tmp_path)
     store.dump(df, name)
     result = store.load(name)
 
     assert_frame_equal(result, df)
+
+
+@pytest.mark.parametrize(
+    "df",
+    [
+        "storable_df_with_unnamed_index",
+        "storable_df_with_named_index",
+        "storable_df_with_named_multiindex",
+        "storable_df_with_unnamed_multiindex",
+    ],
+)
+def test_dump_load_roundtrip_with_inferred_schema(tmp_path, df, lazy_fixture):
+    df = lazy_fixture(df)
+    df1 = df.copy()
+    df2 = df.copy()
+    df1 = df1.etl.add_conditions(conditions=["extra_level"], values=[1])
+    df2 = df2.etl.add_conditions(conditions=["extra_level"], values=[2])
+
+    df1.insert(loc=0, column="extra_columns", value=[[] for _ in range(len(df1))])
+    df2.insert(loc=0, column="extra_columns", value=[[float(i)] for i in range(len(df2))])
+
+    df = pd.concat([df1, df2])
+
+    store = test_module.ParquetStore(tmp_path)
+    store.dump(df1, name="01")
+    store.dump(df2, name="02")
+    result = store.load()
+
+    assert_frame_equal(result, df)
+
+    # in pyarrow 15.0.0, the empty lists in the first DataFrame would cause:
+    #
+    #   pyarrow.lib.ArrowNotImplementedError:
+    #     Unsupported cast from double to null using function cast_null
+    #
+    # if the schema is not inferred correctly from both the files
+    with pytest.raises(ArrowNotImplementedError):
+        store.load(schema=None)

--- a/tests/unit/test_features.py
+++ b/tests/unit/test_features.py
@@ -111,7 +111,7 @@ def test_calculate_features(repo):
         ),
     ]
 
-    result = test_module.calculate_features(repo, features_configs_key, features_configs_list)
+    result = test_module._calculate_features(repo, features_configs_key, features_configs_list)
     assert isinstance(result, list)
     assert len(result) == 1
 

--- a/tests/unit/test_parallel.py
+++ b/tests/unit/test_parallel.py
@@ -91,7 +91,7 @@ def test_merge_groupby():
     df_list = list(all_dataframes.values())
     groupby = ["simulation_id", "circuit_id", "neuron_class"]
 
-    result = test_module.merge_groupby(df_list, groupby=groupby, parallel=False)
+    result = test_module.merge_groupby(df_list, groupby=groupby)
     expected = merge_groupby_classic(df_list, groupby=groupby)
 
     for result_item, expected_item in itertools.zip_longest(result, expected):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -278,3 +278,17 @@ def test_copy_config(tmp_path):
     assert src_sim_campaign_path.is_absolute() is False
     assert dst_sim_campaign_path.is_absolute() is True
     assert (src.parent / src_sim_campaign_path).resolve() == dst_sim_campaign_path.resolve()
+
+
+def test_get_shmdir(monkeypatch, tmp_path):
+    monkeypatch.setenv("SHMDIR", str(tmp_path))
+    shmdir = test_module.get_shmdir()
+    assert shmdir == tmp_path
+
+    monkeypatch.delenv("SHMDIR")
+    shmdir = test_module.get_shmdir()
+    assert shmdir is None
+
+    monkeypatch.setenv("SHMDIR", str(tmp_path / "non-existent"))
+    with pytest.raises(RuntimeError, match="SHMDIR must be set to an existing directory"):
+        test_module.get_shmdir()

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,9 @@ minversion = 4
 setenv =
     # Run serially
     BLUEETL_JOBLIB_JOBS=1
+passenv =
+    SHMDIR
+    TMPDIR
 extras =
     all
 deps =


### PR DESCRIPTION
- Improve performance of report extraction and features calculation by writing partial DataFrames to the shared memory (or temp directory, if shared memory is not available).
  Both the used memory and the execution time should be lower than before, when processing large DataFrames.
- Use zstd compression instead of snappy when writing parquet files.
- When ``repo`` is pickled, extract the DataFrames only if they aren't already stored in the cache.
- Remove fastparquet extra dependency.