### PR TITLE
Ensure that repo and features are filtered if needed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,8 +12,8 @@ Bug Fixes
 Improvements
 ~~~~~~~~~~~~
 
-- Filter features only when ``apply_filter`` is called to save some time.
-- Improve logging in ``utils.timed()``.
+- Filter features only when ``apply_filter`` is called to save some time, but ensure that repo and features are filtered when they are loaded from the cache using a more restrictive filter.
+- Improve logging in ``blueetl.utils.timed()``.
 - Improve tests coverage.
 
 Version 0.8.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 dependencies = [
-    "blueetl-core>=0.1.0",
+    "blueetl-core>=0.2.3",
     "bluepysnap>=1.0.7",
     "click>=8",
     "jsonschema>=4.0",

--- a/src/blueetl/config/analysis.py
+++ b/src/blueetl/config/analysis.py
@@ -44,7 +44,8 @@ def _resolve_trial_steps(global_config: MultiAnalysisConfig, base_path: Path):
     """
     for config in global_config.analysis.values():
         for trial_steps_config in config.extraction.trial_steps.values():
-            trial_steps_config.base_path = str(global_config.output)
+            if not trial_steps_config.base_path:
+                trial_steps_config.base_path = global_config.output
             if path := trial_steps_config.node_sets_file:
                 path = base_path / path
                 trial_steps_config.node_sets_file = path

--- a/src/blueetl/config/analysis_model.py
+++ b/src/blueetl/config/analysis_model.py
@@ -30,7 +30,7 @@ class BaseModel(PydanticBaseModel):
     def json(self, *args, sort_keys=False, **kwargs):
         """Generate a JSON representation of the model, using by_alias=True by default."""
         # use json.dumps because model_dump_json in pydantic v2 doesn't support sort_keys
-        return json.dumps(self.dict(*args, **kwargs), sort_keys=sort_keys)
+        return json.dumps(self.dict(*args, **kwargs), sort_keys=sort_keys, default=str)
 
     def dump(self, path: Path) -> None:
         """Dump the model to file in yaml format."""
@@ -92,6 +92,7 @@ class TrialStepsConfig(BaseModel):
     node_sets_file: Optional[Path] = None
     node_sets_checksum: Optional[str] = None  # to invalidate the cache when the file changes
     limit: Optional[int] = None
+    base_path: Optional[Path] = None  # can be used in the function calculating the trial steps
 
     @model_validator(mode="after")
     def forbid_fields(self):

--- a/src/blueetl/external/bnac/calculate_features.py
+++ b/src/blueetl/external/bnac/calculate_features.py
@@ -168,7 +168,7 @@ def calculate_features_multi(repo, key, df, params):
                 "smoothed_3ms_spike_times_max_normalised_hist_1ms_bin"
             ],
         }
-    ).rename_axis(BIN)
+    ).rename_axis(index=BIN)
 
     return {
         "by_gid": by_gid,

--- a/src/blueetl/features.py
+++ b/src/blueetl/features.py
@@ -267,8 +267,11 @@ class FeaturesCollection:
 
         def _process_cached_features(cached: list[FeaturesConfig]) -> None:
             for n, features_config in enumerate(cached, 1):
+                query = None
+                if self._repo.cache_manager.features_cache_needs_filter(features_config):
+                    query = {SIMULATION_ID: self._repo.simulation_ids}
                 df_dict = self.cache_manager.load_features(features_config=features_config)
-                features = _calculate_cached(features_config, df_dict)
+                features = _calculate_cached(features_config, df_dict, query=query)
                 _process_features(features_config, features)
                 _log_features(features, n, len(cached), features_config.id)
 
@@ -347,10 +350,12 @@ def _dataframes_to_features(
 
 
 def _calculate_cached(
-    features_config: FeaturesConfig, df_dict: dict[str, pd.DataFrame]
+    features_config: FeaturesConfig,
+    df_dict: dict[str, pd.DataFrame],
+    query: Optional[dict],
 ) -> dict[str, Feature]:
     """Load cached features from a dict of DataFrames."""
-    return _dataframes_to_features(df_dict, config=features_config, cached=True, query=None)
+    return _dataframes_to_features(df_dict, config=features_config, cached=True, query=query)
 
 
 def _calculate_new(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -26,6 +26,7 @@ def repo(global_config):
     simulations_config = SimulationCampaign.load(global_config.simulation_campaign)
     extraction_config = global_config.analysis["spikes"].extraction
     cache_manager = PicklableMock(
+        is_repo_cached=PicklableMock(return_value=False),
         load_repo=PicklableMock(return_value=None),
         load_features=PicklableMock(return_value=None),
         get_cached_features_checksums=PicklableMock(return_value={}),


### PR DESCRIPTION
It can happen:
- when they are loaded from the cache using a more restrictive filter
- when apply_filter is executed