### PR TITLE
Restore analysis_config.output, raise if SHMDIR isn't set

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+Version 0.11.0
+--------------
+
+Improvements
+~~~~~~~~~~~~
+
+- Allow to access the cache config and the output path of individual analyses with ``analysis_config.cache`` and ``analysis_config.output``, as a shortcut to ``analysis_config.cache.path``.
+- Raise an error if the env variable ``SHMDIR`` isn't set, instead of logging a warning.
+
+
 Version 0.10.1
 --------------
 

--- a/src/blueetl/analysis.py
+++ b/src/blueetl/analysis.py
@@ -11,7 +11,7 @@ import pandas as pd
 from blueetl.cache import CacheManager
 from blueetl.campaign.config import SimulationCampaign
 from blueetl.config.analysis import init_multi_analysis_configuration
-from blueetl.config.analysis_model import CacheConfig, MultiAnalysisConfig, SingleAnalysisConfig
+from blueetl.config.analysis_model import MultiAnalysisConfig, SingleAnalysisConfig
 from blueetl.features import FeaturesCollection
 from blueetl.repository import Repository
 from blueetl.resolver import AttrResolver, Resolver
@@ -46,7 +46,6 @@ class Analyzer:
         cls,
         analysis_config: SingleAnalysisConfig,
         simulations_config: SimulationCampaign,
-        cache_config: CacheConfig,
         resolver: Resolver,
     ) -> "Analyzer":
         """Initialize the Analyzer from the given configuration.
@@ -54,11 +53,9 @@ class Analyzer:
         Args:
             analysis_config: analysis configuration.
             simulations_config: simulation campaign configuration.
-            cache_config: cache configuration.
             resolver: resolver instance.
         """
         cache_manager = CacheManager(
-            cache_config=cache_config,
             analysis_config=analysis_config,
             simulations_config=simulations_config,
         )
@@ -214,9 +211,6 @@ class MultiAnalyzer:
             name: Analyzer.from_config(
                 analysis_config=analysis_config,
                 simulations_config=simulations_config,
-                cache_config=self.global_config.cache.model_copy(
-                    update={"path": self.global_config.cache.path / name}
-                ),
                 resolver=resolver,
             )
             for name, analysis_config in self.global_config.analysis.items()

--- a/src/blueetl/cache.py
+++ b/src/blueetl/cache.py
@@ -15,7 +15,7 @@ import pandas as pd
 from blueetl_core.utils import is_subfilter
 
 from blueetl.campaign.config import SimulationCampaign
-from blueetl.config.analysis_model import CacheConfig, FeaturesConfig, SingleAnalysisConfig
+from blueetl.config.analysis_model import FeaturesConfig, SingleAnalysisConfig
 from blueetl.store.base import BaseStore
 from blueetl.store.feather import FeatherStore
 from blueetl.store.parquet import ParquetStore
@@ -143,17 +143,17 @@ class CacheManager:
 
     def __init__(
         self,
-        cache_config: CacheConfig,
         analysis_config: SingleAnalysisConfig,
         simulations_config: SimulationCampaign,
     ) -> None:
         """Initialize the object.
 
         Args:
-            cache_config: cache configuration dict.
-            analysis_config: analysis configuration dict.
+            analysis_config: analysis configuration.
             simulations_config: simulations campaign configuration.
         """
+        cache_config = analysis_config.cache
+        assert cache_config is not None
         self._output_dir = cache_config.path
         if cache_config.clear:
             self._clear_cache()

--- a/src/blueetl/config/analysis.py
+++ b/src/blueetl/config/analysis.py
@@ -171,7 +171,9 @@ def _resolve_features(features_config_list: list[FeaturesConfig]) -> list[Featur
 
 
 def _resolve_analysis_configs(global_config: MultiAnalysisConfig) -> None:
-    for config in global_config.analysis.values():
+    global_cache_path = global_config.cache.path
+    for name, config in global_config.analysis.items():
+        config.cache = global_config.cache.model_copy(update={"path": global_cache_path / name})
         config.simulations_filter = global_config.simulations_filter
         config.simulations_filter_in_memory = global_config.simulations_filter_in_memory
         config.features = _resolve_features(config.features)

--- a/src/blueetl/config/analysis_model.py
+++ b/src/blueetl/config/analysis_model.py
@@ -182,6 +182,7 @@ class FeaturesConfig(BaseModel):
 class SingleAnalysisConfig(BaseModel):
     """SingleAnalysisConfig Model."""
 
+    cache: Optional[CacheConfig] = None
     simulations_filter: dict[str, Any] = {}
     simulations_filter_in_memory: dict[str, Any] = {}
     extraction: ExtractionConfig
@@ -203,6 +204,11 @@ class SingleAnalysisConfig(BaseModel):
         # needed to load any cached analysis configuration created with blueetl <= 0.8.2
         data.pop("output", None)
         return data
+
+    @property
+    def output(self) -> Optional[Path]:
+        """Shortcut to the base output path of the analysis."""
+        return self.cache.path if self.cache else None
 
 
 class MultiAnalysisConfig(BaseModel):

--- a/tests/unit/config/test_analysis.py
+++ b/tests/unit/config/test_analysis.py
@@ -1,7 +1,7 @@
 import pytest
 
 from blueetl.config import analysis as test_module
-from blueetl.config.analysis_model import FeaturesConfig, MultiAnalysisConfig
+from blueetl.config.analysis_model import FeaturesConfig, MultiAnalysisConfig, SingleAnalysisConfig
 from blueetl.utils import load_yaml
 from tests.functional.utils import TEST_DATA_PATH as TEST_DATA_PATH_FUNCTIONAL
 from tests.unit.utils import TEST_DATA_PATH as TEST_DATA_PATH_UNIT
@@ -191,3 +191,9 @@ def test_init_multi_analysis_configuration(config_file):
         config_dict, base_path=base_path, extra_params={}
     )
     assert isinstance(result, MultiAnalysisConfig)
+    assert result.cache.path == base_path / config_dict["cache"]["path"]
+    assert len(result.analysis) > 0
+    for name, analysis_config in result.analysis.items():
+        assert isinstance(analysis_config, SingleAnalysisConfig)
+        assert analysis_config.cache is not None
+        assert analysis_config.output == result.cache.path / name

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,4 +1,5 @@
 import json
+from enum import Enum
 from pathlib import Path
 
 import numpy as np
@@ -95,11 +96,16 @@ def test_resolve_path(tmp_path):
 
 
 def test_dump_yaml(tmp_path):
+    class TestEnum(str, Enum):
+        v0 = "v0"
+        v1 = "v1"
+
     data = {
         "dict": {"str": "mystr", "int": 123},
         "list_of_int": [1, 2, 3],
         "list_of_str": ["1", "2", "3"],
         "path": Path("/custom/path"),
+        "enum": TestEnum.v0,
     }
     expected = """
 dict:
@@ -114,6 +120,7 @@ list_of_str:
 - '2'
 - '3'
 path: /custom/path
+enum: v0
     """
     filepath = tmp_path / "test.yaml"
 
@@ -150,7 +157,7 @@ path: /custom/path
     assert loaded_data == expected
 
 
-def test_dump_jaon_load_json_roundtrip(tmp_path):
+def test_dump_json_load_json_roundtrip(tmp_path):
     data = {
         "dict": {"str": "mystr", "int": 123},
         "list_of_int": [1, 2, 3],
@@ -286,8 +293,8 @@ def test_get_shmdir(monkeypatch, tmp_path):
     assert shmdir == tmp_path
 
     monkeypatch.delenv("SHMDIR")
-    shmdir = test_module.get_shmdir()
-    assert shmdir is None
+    with pytest.raises(RuntimeError, match="SHMDIR must be set to the shared memory directory"):
+        test_module.get_shmdir()
 
     monkeypatch.setenv("SHMDIR", str(tmp_path / "non-existent"))
     with pytest.raises(RuntimeError, match="SHMDIR must be set to an existing directory"):

--- a/tox.ini
+++ b/tox.ini
@@ -17,11 +17,10 @@ minversion = 4
 
 [testenv]
 setenv =
+    TMPDIR={env:TMPDIR:/tmp}
+    SHMDIR={env:SHMDIR:{env:TMPDIR}}
     # Run serially
     BLUEETL_JOBLIB_JOBS=1
-passenv =
-    SHMDIR
-    TMPDIR
 extras =
     all
 deps =


### PR DESCRIPTION
- Allow to access the cache config and the output path of individual analyses with ``analysis_config.cache`` and ``analysis_config.output``, as a shortcut to ``analysis_config.cache.path``.
- Raise an error if the env variable ``SHMDIR`` isn't set, instead of logging a warning.