### PR TITLE
Skip simulations with empty path in the sim campaign config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+Version 0.11.5
+--------------
+
+Bug Fixes
+~~~~~~~~~
+
+- Skip simulations with empty path in the simulation campaign configuration (fix regression in blueetl 0.8.0).
+
+
 Version 0.11.4
 --------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ extra = [
 ]
 external = [
     # external requirements needed to run custom code in blueetl.external submodule
-    "elephant>=0.10.0",
+    "elephant>=1.1.0",
     "matplotlib>=3.4.3",
     "quantities>=0.13.0",
     "scipy>=1.8.0",
@@ -152,6 +152,8 @@ ignored-modules = ["bluepy"]
 [tool.pylint.design]
 # Maximum number of arguments for function / method.
 max-args = 8
+# Maximum number of positional arguments for function / method.
+max-positional-arguments = 10
 # Maximum number of attributes for a class (see R0902).
 max-attributes = 40
 # Maximum number of boolean expressions in an if statement (see R0916).

--- a/src/blueetl/adapters/circuit.py
+++ b/src/blueetl/adapters/circuit.py
@@ -16,7 +16,7 @@ class CircuitAdapter(BaseAdapter[CircuitInterface]):
     def from_file(cls, filepath: Optional[Path]) -> "CircuitAdapter":
         """Load and return a new object from file."""
         # pylint: disable=import-outside-toplevel
-        if not filepath or not filepath.exists():
+        if not filepath or not filepath.is_file():
             return cls(None)
         CircuitImpl: type[CircuitInterface]
         if filepath.suffix == ".json":

--- a/src/blueetl/adapters/simulation.py
+++ b/src/blueetl/adapters/simulation.py
@@ -20,7 +20,7 @@ class SimulationAdapter(BaseAdapter[SimulationInterface]):
     def from_file(cls, filepath: Optional[Path]) -> "SimulationAdapter":
         """Load and return a new object from file."""
         # pylint: disable=import-outside-toplevel
-        if not filepath or not filepath.exists():
+        if not filepath or not filepath.is_file():
             return cls(None)
         SimulationImpl: type[SimulationInterface]
         if filepath.suffix == ".json":

--- a/tests/unit/adapters/test_simulation.py
+++ b/tests/unit/adapters/test_simulation.py
@@ -76,8 +76,14 @@ def test_simulation_adapter(path, population, reports, expected_classes, monkeyp
     assert sorted(loaded._impl.__dict__) == ["_simulation"]
 
 
-def test_simulation_adapter_with_nonexistent_path():
-    path = Path("path/to/simulation_config.json")
+@pytest.mark.parametrize(
+    "path",
+    [
+        Path("path/to/missing/simulation_config.json"),
+        Path(""),  # not a file
+    ],
+)
+def test_simulation_adapter_with_nonexistent_path(path):
     obj = test_module.SimulationAdapter.from_file(path)
 
     assert obj.instance is None


### PR DESCRIPTION
 Fix regression in blueetl 0.8.0