### PR TITLE
[NSETM-2336] Do not fail if the simulation campaign is missing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+Version 0.13.0
+--------------
+
+Improvements
+~~~~~~~~~~~~
+
+- When loading the cache, do not fail if the original simulation campaign and related files are missing [NSETM-2336].
+
+
 Version 0.12.1
 --------------
 

--- a/src/blueetl/analysis.py
+++ b/src/blueetl/analysis.py
@@ -206,11 +206,12 @@ class MultiAnalyzer:
     def _init_analyzers(self) -> dict[str, Analyzer]:
         """Load and return a dict of analyzers."""
         resolver = AttrResolver(root=self)
-        simulations_config = SimulationCampaign.load(self.global_config.simulation_campaign)
         return {
             name: Analyzer.from_config(
                 analysis_config=analysis_config,
-                simulations_config=simulations_config,
+                simulations_config=SimulationCampaign.load(
+                    analysis_config.simulation_campaign or self.global_config.simulation_campaign
+                ),
                 resolver=resolver,
             )
             for name, analysis_config in self.global_config.analysis.items()
@@ -351,7 +352,7 @@ def run_from_file(
         readonly_cache: if None, use the value from the configuration file. Otherwise:
             if True, use the existing cache if possible, or raise an error;
             if False, use the existing cache if possible, or update it.
-        skip_features_cache:  if None, use the value from the configuration file. Otherwise:
+        skip_features_cache: if None, use the value from the configuration file. Otherwise:
             if True, do not write the features to the cache;
             if False, write the features to the cache after calculating them.
         loglevel: if specified, used to set up logging.

--- a/src/blueetl/cache.py
+++ b/src/blueetl/cache.py
@@ -16,6 +16,14 @@ from blueetl_core.utils import is_subfilter
 
 from blueetl.campaign.config import SimulationCampaign
 from blueetl.config.analysis_model import FeaturesConfig, SingleAnalysisConfig
+from blueetl.constants import (
+    CACHED_ANALYSIS_CONFIG_FILE,
+    CACHED_CHECKSUMS_FILE,
+    CACHED_CONFIG_DIR,
+    CACHED_FEATURES_DIR,
+    CACHED_REPO_DIR,
+    CACHED_SIMULATIONS_CONFIG_FILE,
+)
 from blueetl.store.base import BaseStore
 from blueetl.store.feather import FeatherStore
 from blueetl.store.parquet import ParquetStore
@@ -157,9 +165,9 @@ class CacheManager:
         self._output_dir = cache_config.path
         if cache_config.clear:
             self._clear_cache()
-        repo_dir = self._output_dir / "repo"
-        features_dir = self._output_dir / "features"
-        config_dir = self._output_dir / "config"
+        repo_dir = self._output_dir / CACHED_REPO_DIR
+        features_dir = self._output_dir / CACHED_FEATURES_DIR
+        config_dir = self._output_dir / CACHED_CONFIG_DIR
         for new_dir in repo_dir, features_dir, config_dir:
             new_dir.mkdir(exist_ok=True, parents=True)
 
@@ -179,9 +187,9 @@ class CacheManager:
         self._lock_manager: LockManagerProtocol = LockManager(self._output_dir)
         self._lock_manager.lock(mode=LockManager.LOCK_SH if self._readonly else LockManager.LOCK_EX)
 
-        self._cached_analysis_config_path = config_dir / "analysis_config.cached.yaml"
-        self._cached_simulations_config_path = config_dir / "simulations_config.cached.yaml"
-        self._cached_checksums_path = config_dir / "checksums.cached.yaml"
+        self._cached_analysis_config_path = config_dir / CACHED_ANALYSIS_CONFIG_FILE
+        self._cached_simulations_config_path = config_dir / CACHED_SIMULATIONS_CONFIG_FILE
+        self._cached_checksums_path = config_dir / CACHED_CHECKSUMS_FILE
 
         self._analysis_configs = CoupledCache[SingleAnalysisConfig](
             cached=self._load_cached_analysis_config(),

--- a/src/blueetl/config/analysis_model.py
+++ b/src/blueetl/config/analysis_model.py
@@ -182,6 +182,7 @@ class FeaturesConfig(BaseModel):
 class SingleAnalysisConfig(BaseModel):
     """SingleAnalysisConfig Model."""
 
+    simulation_campaign: Annotated[Optional[Path], Field(exclude=True)] = None
     cache: Optional[CacheConfig] = None
     simulations_filter: dict[str, Any] = {}
     simulations_filter_in_memory: dict[str, Any] = {}

--- a/src/blueetl/constants.py
+++ b/src/blueetl/constants.py
@@ -50,3 +50,10 @@ LEVEL_SEP = "."
 
 CONFIG_VERSION = 4
 MIN_SUPPORTED_CONFIG_VERSION = 3
+
+CACHED_CONFIG_DIR = "config"
+CACHED_REPO_DIR = "repo"
+CACHED_FEATURES_DIR = "features"
+CACHED_ANALYSIS_CONFIG_FILE = "analysis_config.cached.yaml"
+CACHED_SIMULATIONS_CONFIG_FILE = "simulations_config.cached.yaml"
+CACHED_CHECKSUMS_FILE = "checksums.cached.yaml"

--- a/src/blueetl/utils.py
+++ b/src/blueetl/utils.py
@@ -160,8 +160,22 @@ def resolve_path(*paths: StrOrPath, symlinks: bool = False) -> Path:
     """Make the path absolute and return a new path object.
 
     It may be different from calling Path.resolve(), because Path.resolve() always resolve symlinks.
-    It may be different from calling Path.absolute(), because Path.absolute() doesn't remove the
-    relative paths. For example, Path('/tmp/..').absolute() == PosixPath('/tmp/..').
+    It may be different from calling Path.absolute(), because Path.absolute() doesn't simplify the
+    relative paths.
+
+    For example:
+
+    >>> str(Path('/tmp/..').absolute())
+    '/tmp/..'
+    >>> str(Path('/tmp/..').resolve())
+    '/private'
+    >>> Path(os.path.abspath(Path("/tmp/..")))
+    PosixPath('/')
+
+    However, note that os.path.abspath() might return wrong results. From the official docs:
+
+    |   os.path.abspath() removes ".." components without resolving symlinks, which may change the
+    |   meaning of the path, whereas Path.absolute() leaves any ".." components in the path.
     """
     if symlinks:
         # resolve any symlinks

--- a/tests/unit/config/test_analysis.py
+++ b/tests/unit/config/test_analysis.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import pytest
 
 from blueetl.config import analysis as test_module
@@ -184,7 +186,9 @@ def test_config__resolve_features_error():
         for f in base.glob("*.yaml")
     ],
 )
-def test_init_multi_analysis_configuration(config_file):
+def test_init_multi_analysis_configuration(config_file, monkeypatch):
+    # patch Path.exists() to always return True for the simulation campaign config file
+    monkeypatch.setattr(pathlib.Path, "exists", lambda _: True)
     config_dict = load_yaml(config_file)
     base_path = config_file.parent
     result = test_module.init_multi_analysis_configuration(

--- a/tests/unit/extract/test_simulations.py
+++ b/tests/unit/extract/test_simulations.py
@@ -359,42 +359,6 @@ def test_simulations_from_pandas_load_inconsistent_campaign(mock_simulation_clas
 
 
 @patch(f"{test_module.__name__}.Simulation", autospec=True)
-def test_simulations_from_pandas_first_nonexistent(mock_simulation_class):
-    mock_simulation0 = _get_mock_simulation(exists=False)
-    mock_simulation1 = _get_mock_simulation(exists=True)
-    mock_circuit0 = mock_simulation0.circuit
-    mock_circuit1 = mock_simulation1.circuit
-    mock_simulation_class.from_file.side_effect = [mock_simulation0, mock_simulation1]
-    df = pd.DataFrame(
-        [
-            {
-                "simulation_path": "path1",
-                "seed": 10,
-                "Grating Orientation (degrees)": 0,
-                "simulation_id": 0,
-                "circuit_id": 0,
-            },
-            {
-                "simulation_path": "path2",
-                "seed": 11,
-                "Grating Orientation (degrees)": 45,
-                "simulation_id": 1,
-                "circuit_id": 0,
-            },
-        ]
-    )
-    with pytest.raises(test_module.InconsistentSimulations, match="Inconsistent cache"):
-        test_module.Simulations.from_pandas(df)
-
-    assert mock_simulation_class.from_file.call_count == 2
-    assert mock_circuit0 != mock_circuit1
-    assert mock_simulation0.exists.call_count == 1
-    assert mock_simulation1.exists.call_count == 1
-    assert mock_simulation0.is_complete.call_count == 0
-    assert mock_simulation1.is_complete.call_count == 1
-
-
-@patch(f"{test_module.__name__}.Simulation", autospec=True)
 def test_simulations_from_pandas_filtered_by_simulation_id(mock_simulation_class):
     mock_simulation0 = _get_mock_simulation()
     mock_simulation1 = _get_mock_simulation()


### PR DESCRIPTION
When loading the cache, do not fail if the simulation campaign is missing.

Changes:
- When loading the MultiAnalyzer, if the simulation campaign config file is missing, try to use the config from the cache if it exists. Note that in that case, it's not possible to check that the config file didn't change after the creation of the cache.
- When loading the analysis from the cache, do not filter out any simulation if it's missing