### PR TITLE
Replace license Apache-2.0 with apache-2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "blueetl"
 description = "Multiple simulations analysis tool"
 readme = "README.rst"
 requires-python = ">=3.9"
-license = { text = "Apache-2.0" }
+license = { text = "apache-2.0" }
 authors = [
     { name = "Blue Brain Project, EPFL" },
 ]


### PR DESCRIPTION
Use lowercase to match the id returned by https://sandbox.zenodo.org/api/licenses
This value should be sent to the zenodo webhook as `spdx_id` in:
```
    "license": {
      "key": "apache-2.0",
      "name": "Apache License 2.0",
      "spdx_id": "apache-2.0",
      "url": "https://api.github.com/licenses/apache-2.0",
      "node_id": "MDc6TGljZW5zZTI="
    },
```
(to be confirmed)